### PR TITLE
Add the paper training configs as dedicated Hydra configs

### DIFF
--- a/configs/commands/_base/train_cross_flow_absolute.yaml
+++ b/configs/commands/_base/train_cross_flow_absolute.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: df_cross
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: flow
+
+dataset:
+    type: flow
+    scene: False
+    world_frame: True

--- a/configs/commands/_base/train_cross_flow_relative.yaml
+++ b/configs/commands/_base/train_cross_flow_relative.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: df_cross
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: flow
+
+dataset:
+    type: flow
+    scene: False
+    world_frame: False

--- a/configs/commands/_base/train_cross_point_absolute.yaml
+++ b/configs/commands/_base/train_cross_point_absolute.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: df_cross
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: point
+
+dataset:
+    type: point
+    scene: False
+    world_frame: True

--- a/configs/commands/_base/train_cross_point_relative.yaml
+++ b/configs/commands/_base/train_cross_point_relative.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: df_cross
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: point
+
+dataset:
+    type: point
+    scene: False
+    world_frame: False

--- a/configs/commands/_base/train_regression_flow.yaml
+++ b/configs/commands/_base/train_regression_flow.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: regression
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: flow
+
+dataset:
+    type: flow
+    scene: False
+    world_frame: False

--- a/configs/commands/_base/train_regression_point.yaml
+++ b/configs/commands/_base/train_regression_point.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: regression
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: point
+
+dataset:
+    type: point
+    scene: False
+    world_frame: False

--- a/configs/commands/_base/train_scene_flow.yaml
+++ b/configs/commands/_base/train_scene_flow.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: df_base
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: flow
+
+dataset:
+    type: flow
+    scene: True
+    world_frame: True

--- a/configs/commands/_base/train_scene_point.yaml
+++ b/configs/commands/_base/train_scene_point.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+    - /train@_here_
+    - override /model: df_base
+    - override /dataset: proc_cloth
+    - _self_
+
+model:
+    type: point
+
+dataset:
+    type: point
+    scene: True
+    world_frame: True

--- a/configs/commands/dedo/hangbag/_train_dataset.yaml
+++ b/configs/commands/dedo/hangbag/_train_dataset.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+dataset:
+    cloth_geometry: single
+    hole: single
+    train_size: 400

--- a/configs/commands/dedo/hangbag/cross_flow_relative/train.yaml
+++ b/configs/commands/dedo/hangbag/cross_flow_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_flow_relative@_here_
+    - /commands/dedo/hangbag/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangbag/cross_point_relative/train.yaml
+++ b/configs/commands/dedo/hangbag/cross_point_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_point_relative@_here_
+    - /commands/dedo/hangbag/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_multimodal/_train_dataset.yaml
+++ b/configs/commands/dedo/hangproccloth_multimodal/_train_dataset.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+dataset:
+    cloth_geometry: multi
+    hole: double
+    train_size: 400

--- a/configs/commands/dedo/hangproccloth_multimodal/cross_flow_relative/train.yaml
+++ b/configs/commands/dedo/hangproccloth_multimodal/cross_flow_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_flow_relative@_here_
+    - /commands/dedo/hangproccloth_multimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_multimodal/cross_point_relative/train.yaml
+++ b/configs/commands/dedo/hangproccloth_multimodal/cross_point_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_point_relative@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_multimodal/regression_flow/train.yaml
+++ b/configs/commands/dedo/hangproccloth_multimodal/regression_flow/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_regression_flow@_here_
+    - /commands/dedo/hangproccloth_multimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_multimodal/regression_point/train.yaml
+++ b/configs/commands/dedo/hangproccloth_multimodal/regression_point/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_regression_point@_here_
+    - /commands/dedo/hangproccloth_multimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_simple/_train_dataset.yaml
+++ b/configs/commands/dedo/hangproccloth_simple/_train_dataset.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+dataset:
+    cloth_geometry: single
+    hole: single
+    train_size: 400

--- a/configs/commands/dedo/hangproccloth_simple/cross_flow_relative/train.yaml
+++ b/configs/commands/dedo/hangproccloth_simple/cross_flow_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_flow_relative@_here_
+    - /commands/dedo/hangproccloth_simple/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_simple/cross_point_relative/train.yaml
+++ b/configs/commands/dedo/hangproccloth_simple/cross_point_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_point_relative@_here_
+    - /commands/dedo/hangproccloth_simple/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_unimodal/_train_dataset.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/_train_dataset.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+dataset:
+    cloth_geometry: multi
+    hole: single
+    train_size: 400

--- a/configs/commands/dedo/hangproccloth_unimodal/cross_flow_absolute/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/cross_flow_absolute/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_flow_absolute@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_unimodal/cross_flow_relative/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/cross_flow_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_flow_relative@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_unimodal/cross_flow_relative_nac/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/cross_flow_relative_nac/train.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_flow_relative@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_
+
+model:
+    x0_encoder: null

--- a/configs/commands/dedo/hangproccloth_unimodal/cross_point_absolute/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/cross_point_absolute/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_point_absolute@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_unimodal/cross_point_relative/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/cross_point_relative/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_point_relative@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_unimodal/cross_point_relative_nac/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/cross_point_relative_nac/train.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_cross_point_relative@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_
+
+model:
+    x0_encoder: null

--- a/configs/commands/dedo/hangproccloth_unimodal/scene_flow/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/scene_flow/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_scene_flow@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/configs/commands/dedo/hangproccloth_unimodal/scene_point/train.yaml
+++ b/configs/commands/dedo/hangproccloth_unimodal/scene_point/train.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+defaults:
+    - /commands/_base/train_scene_point@_here_
+    - /commands/dedo/hangproccloth_unimodal/_train_dataset@_here_
+    - _self_

--- a/tests/train_test.py
+++ b/tests/train_test.py
@@ -1,0 +1,93 @@
+# Much around with the path to make the import work
+import os
+import sys
+from pathlib import Path
+
+import omegaconf
+import pytest
+from hydra import compose, initialize
+from hydra.core.hydra_config import HydraConfig
+from omegaconf.dictconfig import DictConfig
+
+# Add the parent directory to the path to import the script. Hacky, but it works.
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.append(str(THIS_DIR.parent))
+
+from scripts.train import main
+
+
+def _discover_training_configs():
+    parent_dirs = [
+        "commands/dedo/hangproccloth_unimodal",
+        "commands/dedo/hangproccloth_simple",
+        "commands/dedo/hangproccloth_multimodal",
+        "commands/dedo/hangbag",
+    ]
+
+    config_names = []
+    for parent_dir in parent_dirs:
+        # Find all files recursively in the parent directory.
+        for root, _, files in os.walk(f"configs/{parent_dir}"):
+            for file in files:
+                if file.endswith("train.yaml"):
+                    config_names.append(os.path.join(root[8:], file[:-5]))
+
+    return config_names
+
+
+GOLDEN_TRAIN_CFGS = _discover_training_configs()
+
+
+@pytest.mark.parametrize("config_name", GOLDEN_TRAIN_CFGS)
+def test_train_cfgs(config_name):
+    with initialize(config_path=str("../configs")):
+        cfg: DictConfig = compose(
+            config_name=config_name,
+            overrides=[
+                # Ugly things we need to add for some unknown reason.
+                "hydra.verbose=true",
+                "hydra.job.num=1",
+                "hydra.job.id=0",
+                "hydra.hydra_help.hydra_help=nil",  # Hack to avoid hydra help.
+                "hydra.runtime.output_dir=.",
+                "seed=1234",
+                "training.batch_size=2",
+                "dataset.data_dir=/path/to/data",
+            ],
+            return_hydra_config=True,
+        )
+        # Resolve the config
+        HydraConfig.instance().set_config(cfg)
+
+        # Resolve the config!
+        container = omegaconf.OmegaConf.to_container(
+            cfg, resolve=True, throw_on_missing=True
+        )
+
+
+# Skip if CLOTH_DATASET_PATH is not set
+@pytest.mark.skipif(
+    not os.environ.get("CLOTH_DATASET_PATH"), reason="CLOTH_DATASET_PATH not set"
+)
+@pytest.mark.parametrize("config_name", GOLDEN_TRAIN_CFGS)
+def test_train(config_name):
+    dataset_dir = os.environ.get("CLOTH_DATASET_PATH")
+
+    with initialize(config_path=str("../configs")):
+        cfg: DictConfig = compose(
+            config_name=config_name,
+            overrides=[
+                "hydra.verbose=true",
+                "hydra.job.num=1",
+                "hydra.runtime.output_dir=.",
+                "seed=1234",
+                "training.batch_size=2",
+                f"dataset.data_dir={dataset_dir}",
+            ],
+            return_hydra_config=True,
+        )
+        # Resolve the config
+        HydraConfig.instance().set_config(cfg)
+
+        os.environ["WANDB_MODE"] = "disabled"
+        main(cfg)


### PR DESCRIPTION
Goal here is to add the training configs as Hydra configs, so they can be loaded and tested. Should be equivalent to the commands provided in the README, but this way if/when we refactor (e.g. dataset, evals) we can make sure golden tests stay golden.

There are two types of tests:

This set of tests makes sure that Hydra is appeased - it's a quick check to make sure everything still resolves if you change the structure.
```
pytest tests/train_test.py -k test_train_cfgs
```

This (optional) set of tests makes sure the training can proceed for ~10 steps for each config. Useful for catching correctness bugs.
```
CLOTH_DATASET_PATH=/home/beisner/datasets/tax3d_data/proccloth pytest tests/train_test.py
```

Handles training for: Table 1, Table 2, Table 3, and Table 4.
