### PR TITLE
fix shuffling in dataloader

### DIFF
--- a/src/non_rigid/datasets/proc_cloth_flow.py
+++ b/src/non_rigid/datasets/proc_cloth_flow.py
@@ -621,7 +621,7 @@ class ProcClothFlowDataModule(L.LightningDataModule):
         return data.DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
-            shuffle=True if self.stage == "train" else False,
+            shuffle=True if self.stage == "fit" else False,
             num_workers=self.num_workers,
             collate_fn=cloth_collate_fn,
         )


### PR DESCRIPTION
- The `stage` in Lightning DataModules are either `fit` or `predict`. Currently the dataloader does not shuffle the data during training