### PR TITLE
Add a script + dependency to launch things on autobot without manual GPU managment.

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -1,0 +1,9 @@
+# Instructions
+
+When running on autobot, you can do something like this:
+
+```bash
+./cluster/launch_autobot.sh -t rtx3090 -n 1 'python scripts/train.py --config-name commands/dedo/hangproccloth_multimodal/cross_flow_relative/train dataset.data_dir=/project_data/held/baeisner/tax3d_data/proccloth'
+```
+
+where the command is fully single-quote wrapped and the dataset path is set to the correct location.

--- a/cluster/launch_autobot.sh
+++ b/cluster/launch_autobot.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# We want an option to take GPU_TYPE and NUM_GPUS as arguments. They should be flags.
+
+# Parse the arguments
+while getopts ":t:n:" opt; do
+  case $opt in
+    t) GPU_TYPE=$OPTARG ;;
+    n) NUM_GPUS=$OPTARG ;;
+    e) CONDA_ENV=$OPTARG ;;
+    \?) echo "Invalid option -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+
+# Shift the arguments so that $@ contains only the command to run
+shift $((OPTIND-1))
+
+# Default values
+GPU_TYPE=${GPU_TYPE:-rtx3090}
+NUM_GPUS=${NUM_GPUS:-1}
+CONDA_ENV=${CONDA_ENV:-tax3d}
+
+OUTPUT=$(python -m rpad.core.autobot available ${GPU_TYPE} ${NUM_GPUS} --quiet --local)
+
+# If the lastr command failed, exit
+if [ $? -ne 0 ]; then
+    # Print the error message
+    echo -e "Error: ${OUTPUT}"
+    exit 1
+fi
+
+# Split the output on the colon
+NODE=${OUTPUT%%:*}
+GPU_INDICES=${OUTPUT#*:}
+COMMAND=$@
+CWD=$(pwd)
+
+# Print the results (optional)
+echo -e "######################################"
+echo -e "Launching job:"
+echo -e "  Node:\t\t${NODE}"
+echo -e "  GPU type:\t${GPU_TYPE}"
+echo -e "  GPU indices:\t${GPU_INDICES}"
+echo -e "  Conda env:\t${CONDA_ENV}"
+echo -e "  Command:\t${COMMAND}"
+echo -e "  CWD:\t\t${CWD}"
+echo -e "######################################"
+
+# For some reason, the -c option causes an error "option requires an argument", but it still works.
+ssh -t ${NODE} bash -ic "
+# Setup env.
+cd $CWD
+
+conda activate $CONDA_ENV
+
+# Now, treat the rest of the command line arguments as the command to run.
+CUDA_VISIBLE_DEVICES=$GPU_INDICES $COMMAND
+
+echo '######################################'
+echo 'Job finished.'
+echo '######################################'
+
+# Deactivate the conda environment.
+conda deactivate
+"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "omegaconf == 2.3.0",
     "pandas",
     "pybullet == 3.2.6",
+    "rpad-core @ git+https://github.com/r-pad/core.git",
     "rpad-pyg @ git+https://github.com/r-pad/pyg_libs.git",
     "rpad-visualize-3d @ git+https://github.com/r-pad/visualize_3d.git",
     "shapely == 2.0.2",


### PR DESCRIPTION
Allows you to do something like:

```
./cluster/launch_autobot.sh -t rtx3090 -n 1 'python scripts/train.py --config-name commands/dedo/hangproccloth_multimodal/cross_flow_relative/train dataset.data_dir=/project_data/held/baeisner/tax3d_data/proccloth'
```

from the head node in autobot (relies on a conda-based flow instead of docker, but could probably be chanced easily), with a conda env activated.